### PR TITLE
0006 basic backend for get requests & object json mapping

### DIFF
--- a/Model/Builders/StandingsBuilder.cs
+++ b/Model/Builders/StandingsBuilder.cs
@@ -13,6 +13,11 @@ namespace HalfboardStats.Model.Builders
     {
         public async Task<Standings> BuildStandings()
         {
+            /*
+             * Method that takes the raw data we get from the JSON file and organizes it in a way that is easier for our front end to work with.
+             * Since there is a lot of logic needed to perform the transfer, this logic is separated out from the class it creates.  It also
+             * serves as a way to separate some logic from classes that will serve as the model for our database.
+             */
             Standings standings = new Standings();
             StandingsMapper mapper = new StandingsMapper();
             StandingsRepository repo = new StandingsRepository();

--- a/Model/Builders/StandingsBuilder.cs
+++ b/Model/Builders/StandingsBuilder.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using HalfboardStats.Model.Repositories;
+using HalfboardStats.Model.ObjectRelationalMappers;
+using HalfboardStats.Model.JsonMappers;
+
+namespace HalfboardStats.Model.Builders
+{
+    public class StandingsBuilder
+    {
+        public async Task<Standings> BuildStandings()
+        {
+            Standings standings = new Standings();
+            StandingsMapper mapper = new StandingsMapper();
+            StandingsRepository repo = new StandingsRepository();
+
+            mapper = await repo.GetStandings();
+
+            for (int i = 0; i < mapper.Records.Count; i++)
+            {
+                for (int j = 0; j < mapper.Records[i].TeamRecords.Count; j++)
+                {
+                    TeamRecord record = new TeamRecord();
+                    record.TeamName = mapper.Records[i].TeamRecords[j].Team.Name;
+                    record.Conference = mapper.Records[i].Conference.Name;
+                    record.Division = mapper.Records[i].Division.Name;
+
+
+                    record.Wins = mapper.Records[i].TeamRecords[j].LeagueRecord.Wins;
+                    record.Losses = mapper.Records[i].TeamRecords[j].LeagueRecord.Losses;
+                    record.OvertimeLosses = mapper.Records[i].TeamRecords[j].LeagueRecord.Ot;
+
+                    record.Points = mapper.Records[i].TeamRecords[j].Points;
+
+                    record.PointsPercentage = (double)record.Points / ((double)(record.Wins + record.Losses + record.OvertimeLosses) * 2);
+
+                    standings.TeamRecords.Add(record);
+                }
+            }
+
+            return standings;
+            
+        }
+    }
+}

--- a/Model/JsonMappers/ConferenceMapper.cs
+++ b/Model/JsonMappers/ConferenceMapper.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
-    public class DivisionMapper
+    public class ConferenceMapper
     {
         public int Id { get; set; }
         public string Name { get; set; }

--- a/Model/JsonMappers/DivisionMapper.cs
+++ b/Model/JsonMappers/DivisionMapper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HalfboardStats.Model.JsonMappers
+{
+    public class DivisionMapper
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Link { get; set; }
+    }
+}

--- a/Model/JsonMappers/DivisionStandingsMapper.cs
+++ b/Model/JsonMappers/DivisionStandingsMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
     public class DivisionStandingsMapper
     {

--- a/Model/JsonMappers/LeagueMapper.cs
+++ b/Model/JsonMappers/LeagueMapper.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
-    public class ConferenceMapper
+    public class LeagueMapper
     {
         public int Id { get; set; }
         public string Name { get; set; }

--- a/Model/JsonMappers/LeagueRecordMapper.cs
+++ b/Model/JsonMappers/LeagueRecordMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
     public class LeagueRecordMapper
     {

--- a/Model/JsonMappers/StandingsMapper.cs
+++ b/Model/JsonMappers/StandingsMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
     public class StandingsMapper
     {

--- a/Model/JsonMappers/TeamMapper.cs
+++ b/Model/JsonMappers/TeamMapper.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
-    public class LeagueMapper
+    public class TeamMapper
     {
         public int Id { get; set; }
         public string Name { get; set; }
         public string Link { get; set; }
+
     }
 }

--- a/Model/JsonMappers/TeamRecordsMapper.cs
+++ b/Model/JsonMappers/TeamRecordsMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace HalfboardStats.Model.ObjectRelationalMappers
+namespace HalfboardStats.Model.JsonMappers
 {
     public class TeamRecordsMapper
     {

--- a/Model/ObjectRelationalMappers/Standings.cs
+++ b/Model/ObjectRelationalMappers/Standings.cs
@@ -5,11 +5,8 @@ using System.Threading.Tasks;
 
 namespace HalfboardStats.Model.ObjectRelationalMappers
 {
-    public class TeamMapper
+    public class Standings
     {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public string Link { get; set; }
-
+        public List<TeamRecord> TeamRecords { get; set; }
     }
 }

--- a/Model/ObjectRelationalMappers/Standings.cs
+++ b/Model/ObjectRelationalMappers/Standings.cs
@@ -8,5 +8,10 @@ namespace HalfboardStats.Model.ObjectRelationalMappers
     public class Standings
     {
         public List<TeamRecord> TeamRecords { get; set; }
+
+        public Standings()
+        {
+            TeamRecords = new List<TeamRecord>();
+        }
     }
 }

--- a/Model/ObjectRelationalMappers/TeamRecord.cs
+++ b/Model/ObjectRelationalMappers/TeamRecord.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HalfboardStats.Model.ObjectRelationalMappers
+{
+    public class TeamRecord
+    {
+        public string Conference { get; set; }
+        public string Division { get; set; }
+        public int Wins { get; set; }
+        public int Losses { get; set; }
+        public int OvertimeLosses { get; set; }
+        public int Points { get; set; }
+        public double PointsPercentage { get; set; }
+
+    }
+}

--- a/Model/ObjectRelationalMappers/TeamRecord.cs
+++ b/Model/ObjectRelationalMappers/TeamRecord.cs
@@ -7,6 +7,7 @@ namespace HalfboardStats.Model.ObjectRelationalMappers
 {
     public class TeamRecord
     {
+        public string TeamName { get; set; }
         public string Conference { get; set; }
         public string Division { get; set; }
         public int Wins { get; set; }

--- a/Model/Repositories/StandingsRepository.cs
+++ b/Model/Repositories/StandingsRepository.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 
 using Newtonsoft.Json;
 
-using HalfboardStats.Model.ObjectRelationalMappers;
+using HalfboardStats.Model.JsonMappers;
 
 namespace HalfboardStats.Model.Repositories
 {

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -6,15 +6,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-using HalfboardStats.Model.JsonMappers;
-using HalfboardStats.Model.Repositories;
+using HalfboardStats.Model.Builders;
+using HalfboardStats.Model.ObjectRelationalMappers;
 
 namespace HalfboardStats.Pages
 {
     public class IndexModel : PageModel
     {
         private readonly ILogger<IndexModel> _logger;
-        private StandingsMapper Standings;
+        private Standings Standings;
 
         public IndexModel(ILogger<IndexModel> logger)
         {
@@ -23,8 +23,8 @@ namespace HalfboardStats.Pages
 
         public async void OnGetAsync()
         {
-            StandingsRepository repo = new StandingsRepository();
-            Standings = await repo.GetStandings();
+            StandingsBuilder builder = new StandingsBuilder();
+            Standings = await builder.BuildStandings();
         }
     }
 }

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-using HalfboardStats.Model.ObjectRelationalMappers;
+using HalfboardStats.Model.JsonMappers;
 using HalfboardStats.Model.Repositories;
 
 namespace HalfboardStats.Pages


### PR DESCRIPTION
Renamed the old ObjectRelationalMappers package to JsonMappers.  The data we get from the NHL's API does not match up well with what our internal database will look like.  We needed to separate out our ORM from our JSON mapping.

Created new ObjectRelationalMappers package that will serve as our future database model.  Also added code that takes what we get from the API for standings and maps it to our ORM class for standings.  This change will make it easier to scale up our design to handle more data from the API while also making it easier for the develop that writes the front end code.  They will not have to worry about which stat is nested where in the JSON mapper.  It will also keep lessen the amount of code needed in each cshtml.cs file that needs to pull standings data.