### PR TITLE
0013 design standings page

### DIFF
--- a/HalfboardStats.sln
+++ b/HalfboardStats.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HalfboardStats", "HalfboardStats.csproj", "{1071C1D5-03C3-45AB-8E10-2132D0243473}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HalfboardStats", "HalfboardStats.csproj", "{1071C1D5-03C3-45AB-8E10-2132D0243473}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Model/Builders/StandingsBuilder.cs
+++ b/Model/Builders/StandingsBuilder.cs
@@ -48,14 +48,41 @@ namespace HalfboardStats.Model.Builders
                 }
             }
 
-            standingsDictionary.Add("League Standings", standings.TeamRecords);
+            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
 
             IEnumerable<TeamRecord> westDivision =
                 from teamRecord in standings.TeamRecords
                 where teamRecord.Division.Contains("West")
                 select teamRecord;
 
-            standingsDictionary.Add("West Division", westDivision);
+            standingsDictionary.Add("WestDivision", westDivision);
+
+            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
+
+            IEnumerable<TeamRecord> northDivision =
+                from teamRecord in standings.TeamRecords
+                where teamRecord.Division.Contains("North")
+                select teamRecord;
+
+            standingsDictionary.Add("WestDivision", westDivision);
+
+            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
+
+            IEnumerable<TeamRecord> centralDivision =
+                from teamRecord in standings.TeamRecords
+                where teamRecord.Division.Contains("Central")
+                select teamRecord;
+
+            standingsDictionary.Add("WestDivision", westDivision);
+
+            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
+
+            IEnumerable<TeamRecord> eastDivision =
+                from teamRecord in standings.TeamRecords
+                where teamRecord.Division.Contains("East")
+                select teamRecord;
+
+            standingsDictionary.Add("WestDivision", westDivision);
 
             return standingsDictionary;
             

--- a/Model/Builders/StandingsBuilder.cs
+++ b/Model/Builders/StandingsBuilder.cs
@@ -57,32 +57,26 @@ namespace HalfboardStats.Model.Builders
 
             standingsDictionary.Add("WestDivision", westDivision);
 
-            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
-
             IEnumerable<TeamRecord> northDivision =
                 from teamRecord in standings.TeamRecords
                 where teamRecord.Division.Contains("North")
                 select teamRecord;
 
-            standingsDictionary.Add("WestDivision", westDivision);
-
-            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
+            standingsDictionary.Add("NorthDivision", westDivision);
 
             IEnumerable<TeamRecord> centralDivision =
                 from teamRecord in standings.TeamRecords
                 where teamRecord.Division.Contains("Central")
                 select teamRecord;
 
-            standingsDictionary.Add("WestDivision", westDivision);
-
-            standingsDictionary.Add("LeagueStandings", standings.TeamRecords);
+            standingsDictionary.Add("CentralDivision", westDivision);
 
             IEnumerable<TeamRecord> eastDivision =
                 from teamRecord in standings.TeamRecords
                 where teamRecord.Division.Contains("East")
                 select teamRecord;
 
-            standingsDictionary.Add("WestDivision", westDivision);
+            standingsDictionary.Add("EastDivision", westDivision);
 
             return standingsDictionary;
             

--- a/Model/Builders/StandingsBuilder.cs
+++ b/Model/Builders/StandingsBuilder.cs
@@ -11,7 +11,7 @@ namespace HalfboardStats.Model.Builders
 {
     public class StandingsBuilder
     {
-        public async Task<Standings> BuildStandings()
+        public async Task<Dictionary<string, IEnumerable<TeamRecord>>> BuildStandings()
         {
             /*
              * Method that takes the raw data we get from the JSON file and organizes it in a way that is easier for our front end to work with.
@@ -21,6 +21,8 @@ namespace HalfboardStats.Model.Builders
             Standings standings = new Standings();
             StandingsMapper mapper = new StandingsMapper();
             StandingsRepository repo = new StandingsRepository();
+
+            Dictionary<string, IEnumerable<TeamRecord>> standingsDictionary = new Dictionary<string, IEnumerable<TeamRecord>>();
 
             mapper = await repo.GetStandings();
 
@@ -46,7 +48,16 @@ namespace HalfboardStats.Model.Builders
                 }
             }
 
-            return standings;
+            standingsDictionary.Add("League Standings", standings.TeamRecords);
+
+            IEnumerable<TeamRecord> westDivision =
+                from teamRecord in standings.TeamRecords
+                where teamRecord.Division.Contains("West")
+                select teamRecord;
+
+            standingsDictionary.Add("West Division", westDivision);
+
+            return standingsDictionary;
             
         }
     }

--- a/Model/Builders/StandingsBuilder.cs
+++ b/Model/Builders/StandingsBuilder.cs
@@ -55,6 +55,8 @@ namespace HalfboardStats.Model.Builders
                 where teamRecord.Division.Contains("West")
                 select teamRecord;
 
+            westDivision = westDivision.OrderByDescending(team => team.Points);
+
             standingsDictionary.Add("WestDivision", westDivision);
 
             IEnumerable<TeamRecord> northDivision =
@@ -62,21 +64,27 @@ namespace HalfboardStats.Model.Builders
                 where teamRecord.Division.Contains("North")
                 select teamRecord;
 
-            standingsDictionary.Add("NorthDivision", westDivision);
+            northDivision = northDivision.OrderByDescending(team => team.Points);
+
+            standingsDictionary.Add("NorthDivision", northDivision);
 
             IEnumerable<TeamRecord> centralDivision =
                 from teamRecord in standings.TeamRecords
                 where teamRecord.Division.Contains("Central")
                 select teamRecord;
 
-            standingsDictionary.Add("CentralDivision", westDivision);
+            centralDivision = centralDivision.OrderByDescending(team => team.Points);
+
+            standingsDictionary.Add("CentralDivision", centralDivision);
 
             IEnumerable<TeamRecord> eastDivision =
                 from teamRecord in standings.TeamRecords
                 where teamRecord.Division.Contains("East")
                 select teamRecord;
 
-            standingsDictionary.Add("EastDivision", westDivision);
+            eastDivision = eastDivision.OrderByDescending(team => team.Points);
+
+            standingsDictionary.Add("EastDivision", eastDivision);
 
             return standingsDictionary;
             

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -14,7 +14,7 @@ namespace HalfboardStats.Pages
     public class IndexModel : PageModel
     {
         private readonly ILogger<IndexModel> _logger;
-        private Standings Standings;
+        public Dictionary<string, IEnumerable<TeamRecord>> Standings { get; set; }
 
         public IndexModel(ILogger<IndexModel> logger)
         {

--- a/Pages/Standings.cshtml
+++ b/Pages/Standings.cshtml
@@ -1,0 +1,42 @@
+﻿@page
+@model HalfboardStats.Pages.StandingsModel
+@{
+    ViewData["Title"] = "Standings";
+}
+
+<div class="container text-white">
+    <h1>Standings</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>
+
+                </th>
+            </tr>
+        </thead>
+        @foreach (var team in Model.Standings.TeamRecords)
+        {
+            <tr class="text-white">
+                <td>
+                    @Html.DisplayFor(modelTeam => team.TeamName)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Wins)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Losses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.OvertimeLosses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Points)
+                </td>
+            </tr>
+        }
+    </table>
+</div>

--- a/Pages/Standings.cshtml
+++ b/Pages/Standings.cshtml
@@ -8,9 +8,156 @@
     <h1>Standings</h1>
     <table class="table">
         <thead>
-            <tr>
+            <tr class="text-white">
                 <th>
+                    East Division
+                </th>
+                <th>
+                    Wins
+                </th>
+                <th>
+                    Losses
+                </th>
+                <th>
+                    Overtime Losses
+                </th>
+                <th>
+                    Points
+                </th>
+            </tr>
+        </thead>
+        @foreach (var team in Model.Standings["EastDivision"])
+        {
+            <tr class="text-white">
+                <td>
+                    @Html.DisplayFor(modelTeam => team.TeamName)
+                </td>
 
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Wins)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Losses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.OvertimeLosses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Points)
+                </td>
+            </tr>
+        }
+    </table>
+    <table class="table">
+        <thead>
+            <tr class="text-white">
+                <th>
+                    North Division
+                </th>
+                <th>
+                    Wins
+                </th>
+                <th>
+                    Losses
+                </th>
+                <th>
+                    Overtime Losses
+                </th>
+                <th>
+                    Points
+                </th>
+            </tr>
+        </thead>
+        @foreach (var team in Model.Standings["NorthDivision"])
+        {
+            <tr class="text-white">
+                <td>
+                    @Html.DisplayFor(modelTeam => team.TeamName)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Wins)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Losses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.OvertimeLosses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Points)
+                </td>
+            </tr>
+        }
+    </table>
+    <table class="table">
+        <thead>
+            <tr class="text-white">
+                <th>
+                    Central Division
+                </th>
+                <th>
+                    Wins
+                </th>
+                <th>
+                    Losses
+                </th>
+                <th>
+                    Overtime Losses
+                </th>
+                <th>
+                    Points
+                </th>
+            </tr>
+        </thead>
+        @foreach (var team in Model.Standings["CentralDivision"])
+        {
+            <tr class="text-white">
+                <td>
+                    @Html.DisplayFor(modelTeam => team.TeamName)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Wins)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Losses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.OvertimeLosses)
+                </td>
+
+                <td>
+                    @Html.DisplayFor(modelTeam => team.Points)
+                </td>
+            </tr>
+        }
+    </table>
+    <table class="table">
+        <thead>
+            <tr class="text-white">
+                <th>
+                    West Division
+                </th>
+                <th>
+                    Wins
+                </th>
+                <th>
+                    Losses
+                </th>
+                <th>
+                    Overtime Losses
+                </th>
+                <th>
+                    Points
                 </th>
             </tr>
         </thead>

--- a/Pages/Standings.cshtml
+++ b/Pages/Standings.cshtml
@@ -14,7 +14,7 @@
                 </th>
             </tr>
         </thead>
-        @foreach (var team in Model.Standings["West Division"])
+        @foreach (var team in Model.Standings["WestDivision"])
         {
             <tr class="text-white">
                 <td>

--- a/Pages/Standings.cshtml
+++ b/Pages/Standings.cshtml
@@ -14,7 +14,7 @@
                 </th>
             </tr>
         </thead>
-        @foreach (var team in Model.Standings.TeamRecords)
+        @foreach (var team in Model.Standings["West Division"])
         {
             <tr class="text-white">
                 <td>

--- a/Pages/Standings.cshtml.cs
+++ b/Pages/Standings.cshtml.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+using HalfboardStats.Model.ObjectRelationalMappers;
+using HalfboardStats.Model.Builders;
+
+namespace HalfboardStats.Pages
+{
+    public class StandingsModel : PageModel
+    {
+        public Standings Standings { get; set; }
+        public async void OnGetAsync()
+        {
+            StandingsBuilder builder = new StandingsBuilder();
+            Standings = await builder.BuildStandings();
+        }
+    }
+}

--- a/Pages/Standings.cshtml.cs
+++ b/Pages/Standings.cshtml.cs
@@ -12,7 +12,7 @@ namespace HalfboardStats.Pages
 {
     public class StandingsModel : PageModel
     {
-        public Standings Standings { get; set; }
+        public Dictionary<string, IEnumerable<TeamRecord>> Standings { get; set; }
         public async void OnGetAsync()
         {
             StandingsBuilder builder = new StandingsBuilder();


### PR DESCRIPTION
Needed to change the data structure for storing standings information to make this work how I wanted it to.  Standings data is all held within a dictionary.  There are keys to extract the entire league standings, or standings by division.  This will get expanded at some point to include other configurations.

Added standings page.  Standings display in descending order.