### PR TITLE
30 iterate players page layout

### DIFF
--- a/HalfboardStats/HalfboardStats.csproj
+++ b/HalfboardStats/HalfboardStats.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/HalfboardStats/Model/Builders/PlayerbaseBuilder.cs
+++ b/HalfboardStats/Model/Builders/PlayerbaseBuilder.cs
@@ -34,6 +34,11 @@ namespace HalfboardStats.Model.Builders
                 person.FirstName = names.First();
                 person.LastName = names.Last();
 
+                person.CurrentTeam = new Team();
+
+                person.CurrentTeam.Id = playerMapper[i].Person.currentTeam.Id;
+                person.CurrentTeam.TeamName = playerMapper[i].Person.currentTeam.Name;
+
                 players.Add(person);
 
             }

--- a/HalfboardStats/Model/JsonMappers/PlayerMappers/PersonMapper.cs
+++ b/HalfboardStats/Model/JsonMappers/PlayerMappers/PersonMapper.cs
@@ -10,5 +10,6 @@ namespace HalfboardStats.Model.JsonMappers
         public int Id { get; set; }
         public string FullName { get; set; }
         public string Link { get; set; }
+        public TeamMapper currentTeam { get; set; }
     }
 }

--- a/HalfboardStats/Model/JsonMappers/PlayerMappers/RosterPersonMapper.cs
+++ b/HalfboardStats/Model/JsonMappers/PlayerMappers/RosterPersonMapper.cs
@@ -16,5 +16,7 @@ namespace HalfboardStats.Model.JsonMappers
         public PersonMapper Person { get; set; }
         public int JerseyNumber { get; set; }
         public PositionMapper Position { get; set; }
+
+
     }
 }

--- a/HalfboardStats/Model/Repositories/PlayerRepository.cs
+++ b/HalfboardStats/Model/Repositories/PlayerRepository.cs
@@ -48,7 +48,7 @@ namespace HalfboardStats.Model.Repositories
                 }
             }
 
-            leagueTeamString += "&expand=team.roster";
+            leagueTeamString += "&expand=team.roster&expand=roster.person";
 
             responseTask = client.GetAsync(leagueTeamString);
             responseTask.Wait();
@@ -64,6 +64,7 @@ namespace HalfboardStats.Model.Repositories
 
                 foreach (var player in leagueRosterMapper.Teams[i].Roster.Roster)
                 {
+                    
                     people.Add(player);
                 }
 

--- a/HalfboardStats/Pages/Players.cshtml
+++ b/HalfboardStats/Pages/Players.cshtml
@@ -16,6 +16,9 @@
                 <th>
                     Last Name
                 </th>
+                <th>
+                    Team
+                </th>
             </tr>
         </thead>
         @foreach (var player in Model.Players)
@@ -32,6 +35,10 @@
                 <td>
                     @Html.DisplayFor(modelPlayer => player.LastName)
                 </td>
+                <td>
+                    @Html.DisplayFor(modelPlayer => player.CurrentTeam.TeamName)
+                </td>
             </tr>
         }
     </table>
+    </div>


### PR DESCRIPTION
Added support to display the team name a player is associated with on the players page.  It appears that we are approaching the limit of what we can display for players from pulling data straight from the NHL Stats API.  I will leave it at this for now to work on our persistent database.